### PR TITLE
Private plugins should be executed within app dir

### DIFF
--- a/scripts/private-plugins.sh
+++ b/scripts/private-plugins.sh
@@ -7,7 +7,7 @@ source /home/ubuntu/.ssh/environment
 _dir="$(dirname "$0")"
 plugins="meta-box-group-1.1.1.zip meta-box-include-exclude-1.0.3.zip meta-box-conditional-logic-1.3.0.zip wpfront-user-role-editor-personal-pro-2.12.5.zip"
 
-cd /home/ubuntu/app/wp
+cd /home/ubuntu/app
 for plugin in $plugins; do
   #wp plugin install --quiet --force --activate "$("$_dir/s3url.sh" "$PHILA_PLUGIN_BUCKET" "$plugin")" > /dev/null
   echo "--- Installing $plugin ---"


### PR DESCRIPTION
See chat log for details. This should fix the `No such file or directory` errors

<img width="1154" alt="screen shot 2016-10-07 at 12 58 42" src="https://cloud.githubusercontent.com/assets/761444/19201513/24830150-8c9c-11e6-8d04-285ff3e021bb.png">
